### PR TITLE
Turn Python keyword arguments into Lisp keyword arguments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ modules, like this:
     >>> cl.cons(5, None)
     List(5)
 
-    >>> cl.remove(5, [1, 5, 2, 7, 5, 9])
+    >>> cl.remove(5, [1, -5, 2, 7, 5, 9], key=cl.abs)
     [1, 2, 7, 9]
 
     # Higher-order functions work, too!

--- a/cl4py/data.py
+++ b/cl4py/data.py
@@ -239,5 +239,9 @@ class LispWrapper (LispObject):
         except:
             pass
 
-    def __call__(self, *args):
-        return self.lisp.eval(List(Symbol('FUNCALL', 'CL'), Quote(self), *[Quote(arg) for arg in args]))
+    def __call__(self, *args, **kwargs):
+        restAndKeys = [ Quote(arg) for arg in args ]
+        for key, value in kwargs.items():
+            restAndKeys.append(Keyword(key.upper()))
+            restAndKeys.append(Quote(value))
+        return self.lisp.eval(List(Symbol('FUNCALL', 'CL'), Quote(self), *restAndKeys))


### PR DESCRIPTION
This came to my mind when @drmeister asked. Maybe there this has a problem I missed.