### PR TITLE
Control the use of the cl4py readtable.

### DIFF
--- a/cl4py/data.py
+++ b/cl4py/data.py
@@ -163,6 +163,12 @@ class Cons (LispObject):
         else:
             raise RuntimeError('Not a function name: {}'.format(self))
 
+    def __eq__(self, other) -> bool:
+        if isinstance(other, Cons):
+            return self.car == other.car and self.cdr == other.cdr
+        else:
+            return False
+
 
 class ListIterator:
     def __init__(self, elt):

--- a/test/sample-program.lisp
+++ b/test/sample-program.lisp
@@ -1,0 +1,4 @@
+(in-package :common-lisp-user)
+
+(defun foo-{a7lkj9lakj} ()
+  nil)

--- a/test/test_for_readtable.py
+++ b/test/test_for_readtable.py
@@ -1,0 +1,39 @@
+from pytest import fixture
+import cl4py
+import os
+
+# pytest forces violation of this pylint rule
+# pylint: disable=redefined-outer-name
+
+
+@fixture(scope="module")
+def lisp():
+    return cl4py.Lisp()
+
+
+@fixture(scope="module")
+def cl(lisp):
+    return lisp.function("find-package")("CL")
+
+
+# This test verifies issue underlying MR #9
+def test_readtable_problem(cl):
+    retval = cl.compile_file(
+        os.path.join(os.path.dirname(__file__), "sample-program.lisp")
+    )
+    outfile = os.path.join(os.path.dirname(__file__), "sample-program.fasl")
+    try:
+        assert retval[0] == outfile
+        assert os.path.exists(retval[0])
+        assert retval[1] == ()
+        assert retval[2] == ()
+    finally:
+        cleanup(outfile)
+    cleanup(outfile)
+
+def cleanup(outfile):
+    if os.path.exists(outfile):
+        try:
+            os.remove(outfile)
+        except:                 # pylint: disable=bare-except
+            pass

--- a/test/test_from_readme.py
+++ b/test/test_from_readme.py
@@ -1,0 +1,62 @@
+from pytest import fixture
+import fractions
+
+import cl4py
+from cl4py import List, Symbol
+
+# pytest forces violation of this pylint rule
+# pylint: disable=redefined-outer-name
+
+@fixture(scope="module")
+def lisp():
+    return cl4py.Lisp()
+
+
+@fixture(scope="module")
+def cl(lisp):
+    return lisp.function("find-package")("CL")
+
+
+def test_startup(lisp):
+    assert isinstance(lisp, cl4py.Lisp)
+
+
+def test_examples(lisp):
+    assert lisp.eval(("+", 2, 3)) == 5
+    add = lisp.function("+")
+    assert add(1, 2, 3, 4) == 10
+    div = lisp.function("/")
+    assert div(2, 4) == fractions.Fraction(1, 2)
+    assert lisp.eval(cl4py.Symbol("*PRINT-BASE*", "COMMON-LISP")) == 10
+    assert lisp.eval(("CONS", 1, 2)) == cl4py.Cons(1, 2)
+    lst = lisp.eval(("CONS", 1, ("CONS", 2, ())))
+    assert lst == cl4py.List(1, 2)
+    assert lst.car == 1
+    assert lst.cdr == cl4py.List(2)
+    assert list(lst) == [1, 2]
+    assert sum(lst) == 3
+
+
+def test_finding_functions(cl):
+    assert cl.oddp(5)
+    assert cl.cons(5, None) == cl4py.List(5)
+    assert cl.remove(5, [1, -5, 2, 7, 5, 9], key=cl.abs) == [1, 2, 7, 9]
+
+
+def test_pythony_names(cl):
+    assert cl.type_of("foo") == List(
+        Symbol("SIMPLE-ARRAY", "COMMON-LISP"),
+        Symbol("CHARACTER", "COMMON-LISP"),
+        List(3),
+    )
+
+
+def test_higher_order(cl):
+    assert cl.mapcar(cl.constantly(4), (1, 2, 3)) == List(4, 4, 4)
+
+
+def test_circular_objects(cl, lisp):
+    twos = cl.cons(2, 2)
+    twos.cdr = twos
+    assert cl.mapcar(lisp.function("+"), (1, 2, 3, 4), twos) == \
+        List(3, 4, 5, 6)


### PR DESCRIPTION
The cl4py readtable is wrapped around *everything* done by Lisp running inside cl4py, instead of just being wrapped around reading from the stream of inputs from python.

In particular, this means that any lisp code compiled by cl4py is read with the cl4py readtable, which can cause breakage if the standard readtable is expected.

This tweak makes the cl4py readtable apply only around the `read` rather than the `read` and the `eval`, as before.
