### PR TITLE
Add option for backtrace on runtime errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ __pycache__/
 *~
 .cache
 .mypy_cache
-.DS_Store
+.DS_Store*.fasl

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ext/trivial-backtrace"]
+	path = ext/trivial-backtrace
+	url = https://gitlab.common-lisp.net/rgoldman/trivial-backtrace.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ext/trivial-backtrace"]
-	path = ext/trivial-backtrace
-	url = https://gitlab.common-lisp.net/rgoldman/trivial-backtrace.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language: python
 python:
   - "3.7"
   - "3.8"
-  - "3.8-dev"  # 3.8 development branch
-  - "nightly"  # nightly build
+  - "3.9"
+  # Don't test on 3.10
+  # - "nightly"  # nightly build
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+
+python:
+  - "3.7"
+  - "3.8"
+  - "3.8-dev"  # 3.8 development branch
+  - "nightly"  # nightly build
+
+addons:
+  apt:
+    update: true
+
+before_install:
+  - sudo apt-get -y install sbcl
+
+# command to install dependencies
+install:
+  - pip install -e .
+
+# command to run tests
+script:
+  - pytest

--- a/cl4py/lisp.py
+++ b/cl4py/lisp.py
@@ -13,7 +13,7 @@ _DEFAULT_COMMAND = ('sbcl', '--script')
 
 class Lisp:
     debug: bool
-    backtrace: bool
+    _backtrace: bool
 
     def __init__(self, cmd=_DEFAULT_COMMAND, quicklisp=False, debug=False,
                  backtrace=False):
@@ -44,8 +44,18 @@ class Lisp:
             install_and_load_quicklisp(self)
         #if backtrace:
         #    self.load_trivial_backtrace(quicklisp)
-        self.backtrace = backtrace
+        self._backtrace = backtrace
         self.eval( ('defparameter', 'cl4py::*backtrace*', backtrace) )
+
+    @property
+    def backtrace(self) -> bool:
+        return self._backtrace
+
+    @backtrace.setter
+    def backtrace(self, value: bool) -> bool:
+        self.eval ( ('setf', 'cl4py::*backtrace*', value))
+        self._backtrace = value
+        return self._backtrace
 
 
     def __del__(self):

--- a/cl4py/py.lisp
+++ b/cl4py/py.lisp
@@ -31,6 +31,8 @@
 
 (in-package #:cl4py)
 
+(defvar *backtrace* nil)
+
 ;;; Welcome to the Lisp side of cl4py. Basically, this is just a REPL that
 ;;; reads expressions from the Python side and prints results back to
 ;;; Python.
@@ -785,12 +787,20 @@
             ;; Second, write the obtained value.
             (pyprint value python)
             ;; Third, write the obtained condition, or NIL.
-            (if (not condition)
-                (pyprint nil python)
+            (if condition
                 (pyprint
                  (list (class-name (class-of condition))
+                       (if *backtrace*
+                           (concatenate 'string
+                                        (condition-string condition)
+                                        (with-output-to-string (str)
+                                          (funcall (intern "PRINT-CONDITION-BACKTRACE"
+                                                           (find-package :uiop))
+                                                   condition
+                                                   :stream str))))
                        (condition-string condition))
-                 python))
+                 python)
+                (pyprint nil python))
             ;; Fourth, write the output that has been obtained so far.
             (finish-output python)
             (pyprint (get-output-stream-string lisp-output) python)))))))

--- a/test/sample-program.lisp
+++ b/test/sample-program.lisp
@@ -6,3 +6,8 @@
 (defun make-error ()
   (error "Artificial error"))
 
+(defun make-type-error ()
+  (error 'type-error :datum 'fake-variable :expected-type t)
+  )
+
+(export '(make-error make-type-error))

--- a/test/sample-program.lisp
+++ b/test/sample-program.lisp
@@ -2,3 +2,7 @@
 
 (defun foo-{a7lkj9lakj} ()
   nil)
+
+(defun make-error ()
+  (error "Artificial error"))
+

--- a/test/test_backtrace.py
+++ b/test/test_backtrace.py
@@ -1,12 +1,31 @@
+import os
+import re
 import pytest
 import cl4py
 from cl4py import List, Symbol
+
+# FIXME: should have test for quicklisp, but that would require a test
+# install of QL...
+
+@pytest.fixture()
+def stock_lisp():
+    return cl4py.Lisp()
+
+@pytest.fixture()
+def backtrace_lisp():
+    return cl4py.Lisp(backtrace=True)
+
+def load_sample_program(lisp_obj: cl4py.Lisp) -> None:
+    cl = lisp_obj.find_package("COMMON-LISP")
+    retval = cl.compile_file(
+        os.path.join(os.path.dirname(__file__), "sample-program.lisp")
+    )
+    cl.load(retval[0])
 
 def test_backtrace_param():
     lisp = cl4py.Lisp(backtrace=True)
     assert lisp.eval( Symbol("*BACKTRACE*", "CL4PY") )
     assert lisp.backtrace
-    assert lisp.find_package("TRIVIAL-BACKTRACE")
     lisp = cl4py.Lisp(backtrace=False)
     assert not lisp.eval( Symbol("*BACKTRACE*", "CL4PY"))
     assert not lisp.backtrace
@@ -25,4 +44,35 @@ def test_backtrace_setting():
     lisp.backtrace = True
     assert lisp.eval( Symbol("*BACKTRACE*", "CL4PY"))
     assert lisp.backtrace
-    assert lisp.find_package("TRIVIAL-BACKTRACE")
+
+def test_produce_backtrace_type_error(stock_lisp, backtrace_lisp):
+    with pytest.raises(RuntimeError):
+        load_sample_program(stock_lisp)
+        stock_lisp.find_package("COMMON-LISP-USER").make_type_error()
+
+    lisp = cl4py.Lisp(backtrace=True, quicklisp=True)
+    load_sample_program(lisp)
+    try:
+        lisp.find_package("COMMON-LISP-USER").make_type_error()
+    except RuntimeError as e:
+        msg = e.args[0]
+        backtrace_re = re.compile('Backtrace', re.MULTILINE)
+        assert re.search(backtrace_re, msg)
+    else:
+        pytest.fail("Should have seen a RuntimeError")
+
+def test_produce_backtrace_simple_error(stock_lisp, backtrace_lisp):
+    with pytest.raises(RuntimeError):
+        load_sample_program(stock_lisp)
+        stock_lisp.find_package("COMMON-LISP-USER").make_error()
+
+
+    load_sample_program(backtrace_lisp)
+    try:
+        backtrace_lisp.find_package("COMMON-LISP-USER").make_error()
+    except RuntimeError as e:
+        msg = e.args[0]
+        backtrace_re = re.compile('Backtrace', re.MULTILINE)
+        assert re.search(backtrace_re, msg)
+    else:
+        pytest.fail("Should have seen a RuntimeError")

--- a/test/test_backtrace.py
+++ b/test/test_backtrace.py
@@ -6,6 +6,7 @@ def test_backtrace_param():
     lisp = cl4py.Lisp(backtrace=True)
     assert lisp.eval( Symbol("*BACKTRACE*", "CL4PY") )
     assert lisp.backtrace
+    assert lisp.find_package("TRIVIAL-BACKTRACE")
     lisp = cl4py.Lisp(backtrace=False)
     assert not lisp.eval( Symbol("*BACKTRACE*", "CL4PY"))
     assert not lisp.backtrace
@@ -17,3 +18,11 @@ def test_backtrace_setting():
     lisp.backtrace = False
     assert not lisp.eval( Symbol("*BACKTRACE*", "CL4PY"))
     assert not lisp.backtrace
+
+    lisp = cl4py.Lisp(backtrace=False)
+    assert not lisp.eval( Symbol("*BACKTRACE*", "CL4PY") )
+    assert not lisp.backtrace
+    lisp.backtrace = True
+    assert lisp.eval( Symbol("*BACKTRACE*", "CL4PY"))
+    assert lisp.backtrace
+    assert lisp.find_package("TRIVIAL-BACKTRACE")

--- a/test/test_backtrace.py
+++ b/test/test_backtrace.py
@@ -1,0 +1,9 @@
+import pytest
+import cl4py
+from cl4py import List, Symbol
+
+def test_backtrace_param():
+    lisp = cl4py.Lisp(backtrace=True)
+    assert lisp.eval( Symbol("*BACKTRACE*", "CL4PY") )
+    lisp = cl4py.Lisp(backtrace=False)
+    assert not lisp.eval( Symbol("*BACKTRACE*", "CL4PY"))

--- a/test/test_backtrace.py
+++ b/test/test_backtrace.py
@@ -5,5 +5,15 @@ from cl4py import List, Symbol
 def test_backtrace_param():
     lisp = cl4py.Lisp(backtrace=True)
     assert lisp.eval( Symbol("*BACKTRACE*", "CL4PY") )
+    assert lisp.backtrace
     lisp = cl4py.Lisp(backtrace=False)
     assert not lisp.eval( Symbol("*BACKTRACE*", "CL4PY"))
+    assert not lisp.backtrace
+
+def test_backtrace_setting():
+    lisp = cl4py.Lisp(backtrace=True)
+    assert lisp.eval( Symbol("*BACKTRACE*", "CL4PY") )
+    assert lisp.backtrace
+    lisp.backtrace = False
+    assert not lisp.eval( Symbol("*BACKTRACE*", "CL4PY"))
+    assert not lisp.backtrace

--- a/test/test_from_readme.py
+++ b/test/test_from_readme.py
@@ -1,6 +1,8 @@
-from pytest import fixture
+import os
+import pytest
 import fractions
 
+from pytest import fixture
 import cl4py
 from cl4py import List, Symbol
 
@@ -60,3 +62,11 @@ def test_circular_objects(cl, lisp):
     twos.cdr = twos
     assert cl.mapcar(lisp.function("+"), (1, 2, 3, 4), twos) == \
         List(3, 4, 5, 6)
+
+def test_error(cl, lisp):
+    retval = cl.compile_file(
+        os.path.join(os.path.dirname(__file__), "sample-program.lisp")
+    )
+    cl.load(retval[0])
+    with pytest.raises(RuntimeError):
+        lisp.eval( ("CL-USER::MAKE-ERROR", ))


### PR DESCRIPTION
Uses `UIOP:PRINT-CONDITION-BACKTRACE` to implement `backtrace` option for `Lisp` objects.

**Note:** This branch should *definitely* be squash merged because the history is messy.