### PR TITLE
Delay deleting handles until the next Lisp.eval call

### DIFF
--- a/cl4py/data.py
+++ b/cl4py/data.py
@@ -269,10 +269,7 @@ class LispWrapper (LispObject):
         self.handle = handle
 
     def __del__(self):
-        try:
-            self.lisp.eval('#{}!'.format(self.handle))
-        except:
-            pass
+        self.lisp.to_free.append(self.handle)
 
     def __call__(self, *args, **kwargs):
         restAndKeys = [ Quote(arg) for arg in args ]


### PR DESCRIPTION
Fixes #25.

This delays the deletion of handles until the next `Lisp.eval` call. Handles to be deleted are stored in a deque, which is modified using `append` and `popleft`. These operation are indirectly documented as atomic on the [synchronized queue](https://docs.python.org/3/library/queue.html) page:
> [`collections.deque`](https://docs.python.org/3/library/collections.html#collections.deque) is an alternative implementation of unbounded queues with fast atomic [`append()`](https://docs.python.org/3/library/collections.html#collections.deque.append) and [`popleft()`](https://docs.python.org/3/library/collections.html#collections.deque.popleft) operations that do not require locking and also support indexing.

However, the documentation page for [deque](https://docs.python.org/3/library/collections.html#collections.deque) only explicitely mentions thread-safety:
>  Deques support thread-safe, memory efficient appends and pops from either side of the deque with approximately the same O(1) performance in either direction.

Since locking in `__del__` doesn't seem to be safe, this might not be the ideal solution.
> If [`__del__()`](https://docs.python.org/3/reference/datamodel.html#object.__del__) needs to take a lock or invoke any other blocking resource, it may deadlock as the resource may already be taken by the code that gets interrupted to execute [`__del__()`](https://docs.python.org/3/reference/datamodel.html#object.__del__).