### PR TITLE
allow modern setuptools without pkg_resources

### DIFF
--- a/cl4py/lisp.py
+++ b/cl4py/lisp.py
@@ -3,13 +3,21 @@ import io
 import os.path
 from urllib import request
 import tempfile
-from pkg_resources import resource_filename
 from collections import deque
 from .data import LispWrapper, Cons, Symbol, Quote
 from .reader import Readtable
 from .writer import lispify
 
 _DEFAULT_COMMAND = ('sbcl', '--script')
+
+try:
+    from pkg_resources import resource_filename
+    def _r_filename():
+        return resource_filename(__name__, 'py.lisp')
+except (ImportError):
+    from importlib.resources import files
+    def _r_filename():
+        return str(files(__name__).joinpath('py.lisp'))
 
 
 class Lisp:
@@ -19,7 +27,7 @@ class Lisp:
     def __init__(self, cmd=_DEFAULT_COMMAND, quicklisp=False, debug=False,
                  backtrace=True):
         command = list(cmd)
-        p = subprocess.Popen(command + [resource_filename(__name__, 'py.lisp')],
+        p = subprocess.Popen(command + [_r_filename()],
                              stdin = subprocess.PIPE,
                              stdout = subprocess.PIPE,
                              stderr = subprocess.PIPE,


### PR DESCRIPTION
pkg_resources is deprecated, and removed in the latest Setuptools. Thus their use has to be replaced, following e.g. recommendations in https://setuptools.pypa.io/en/latest/pkg_resources.html

Without this patch, one gets
```
$ python3
Python 3.13.9 (main, Oct 25 2025, 23:32:23) [GCC 15.2.1 20251018] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import cl4py
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    import cl4py
  File "/home/dima/tmp/.venv/lib/python3.13/site-packages/cl4py/__init__.py", line 2, in <module>
    from .lisp import Lisp
  File "/home/dima/tmp/.venv/lib/python3.13/site-packages/cl4py/lisp.py", line 6, in <module>
    from pkg_resources import resource_filename
ModuleNotFoundError: No module named 'pkg_resources'
>>> 
```